### PR TITLE
Adding google() dependency in build.gradle file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {


### PR DESCRIPTION
Fixing "couldn't find com.android.tools.build:gradle:1.1.3" error