### PR TITLE
upped compileSDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Whenever i build my apk, gradle fails to build because the some android values cant be found. I changed it locally in my project, but everytime another dev runs npm install the dependency is broken again.