### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.evernote:android-job:1.1.11'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.evernote:android-job:1.1.11'
 }


### PR DESCRIPTION
'compile' is deprecated  now, it should be 'implementation' ... because it is causing errors on build