### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.evernote:android-job:1.1.11'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.evernote:android-job:1.1.11'
 }


### PR DESCRIPTION
The compile() method has been deprecated in newer versions of Gradle, so it's possible that you need to change it to implementation().